### PR TITLE
Add minimal frontend and backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+frontend/build/
+backend/node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Proposia Document Generator
+
+Cette application ultra-simple permet de générer un document professionnel à partir d'un cahier des charges téléchargé par l'utilisateur. Elle se compose d'un frontend React et d'un backend Express servant d'interface avec un workflow n8n.
+
+## Arborescence
+```
+frontend/
+  index.html
+  public/
+    proposia.png
+  src/
+    components/
+      FileUpload.jsx
+      Loader.jsx
+    App.jsx
+    index.jsx
+    styles.css
+  package.json
+  vite.config.js
+backend/
+  index.js
+  package.json
+```
+
+## Lancer le projet
+
+Frontend (compatible Netlify)
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Backend
+```bash
+cd backend
+npm install
+node index.js
+```
+
+Le backend attend l'URL du webhook n8n dans la variable d'environnement `N8N_WEBHOOK_URL`.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,36 @@
+import express from 'express';
+import multer from 'multer';
+import axios from 'axios';
+import htmlDocx from 'html-docx-js';
+
+const upload = multer({ storage: multer.memoryStorage() });
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.post('/generate', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).send('No file');
+  }
+  try {
+    // Forward the file to n8n workflow
+    const response = await axios.post(process.env.N8N_WEBHOOK_URL, req.file.buffer, {
+      headers: { 'Content-Type': req.file.mimetype }
+    });
+
+    // Assuming n8n returns { html: '<html>...</html>' }
+    const html = response.data.html;
+    const docxBuffer = htmlDocx.asBlob(html);
+    res.set({
+      'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'Content-Disposition': 'attachment; filename="document.docx"'
+    });
+    res.send(docxBuffer);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Generation error');
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "proposia-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5",
+    "axios": "^1.5.0",
+    "html-docx-js": "^0.4.1"
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Proposia Document Generator</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "proposia-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import FileUpload from './components/FileUpload';
+import Loader from './components/Loader';
+
+export default function App() {
+  const [file, setFile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [downloadUrl, setDownloadUrl] = useState('');
+
+  const handleGenerate = async () => {
+    if (!file) {
+      setError('Aucun fichier sélectionné');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const response = await axios.post('/api/generate', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+        responseType: 'blob'
+      });
+      const blob = new Blob([response.data], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
+      const url = window.URL.createObjectURL(blob);
+      setDownloadUrl(url);
+    } catch (err) {
+      setError('Erreur lors de la génération');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container">
+      <header>
+        <img src="/proposia.png" alt="Proposia logo" className="logo" />
+      </header>
+      <h1>Générez automatiquement vos documents professionnels</h1>
+      <p>Déposez votre cahier des charges au format .txt, .docx ou .pdf puis cliquez sur Générer</p>
+      <FileUpload onFileSelected={setFile} />
+      {error && <p className="error">{error}</p>}
+      <button className="generate-btn" onClick={handleGenerate}>Générer le document</button>
+      {loading && <Loader />}
+      {downloadUrl && (
+        <a href={downloadUrl} download="document.docx" className="download-btn">
+          Télécharger le document généré
+        </a>
+      )}
+      <footer>
+        &copy; {new Date().getFullYear()} Proposia
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,0 +1,27 @@
+import React, { useRef, useState } from 'react';
+
+export default function FileUpload({ onFileSelected }) {
+  const inputRef = useRef();
+  const [fileName, setFileName] = useState('');
+
+  const handleChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      setFileName(file.name);
+      onFileSelected(file);
+    }
+  };
+
+  return (
+    <div className="upload-container" onClick={() => inputRef.current.click()}>
+      <input
+        type="file"
+        accept=".txt,.pdf,.docx"
+        ref={inputRef}
+        onChange={handleChange}
+        style={{ display: 'none' }}
+      />
+      <p>{fileName || 'Choisir un fichier'}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/Loader.jsx
+++ b/frontend/src/components/Loader.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Loader() {
+  return (
+    <div className="loader">
+      <div className="spinner"></div>
+      <p>Votre document est en cours de traitement…</p>
+    </div>
+  );
+}

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,76 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+  color: #333;
+  text-align: center;
+}
+
+.container {
+  padding: 2rem;
+}
+
+.logo {
+  height: 50px;
+}
+
+.upload-container {
+  border: 2px dashed #aaa;
+  padding: 2rem;
+  margin: 1rem auto;
+  max-width: 400px;
+  cursor: pointer;
+}
+
+.generate-btn {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+.generate-btn:hover {
+  box-shadow: 0 0 10px #007bff;
+}
+
+.download-btn {
+  display: inline-block;
+  margin-top: 1rem;
+  background-color: #28a745;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
+.error {
+  color: red;
+}
+
+.loader {
+  margin-top: 1rem;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #007bff;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+footer {
+  margin-top: 3rem;
+  font-size: 0.8rem;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'build'
+  }
+});


### PR DESCRIPTION
## Summary
- add README with folder structure and instructions
- create React frontend using Vite
- add simple upload page and loader
- implement Express backend to call n8n and convert HTML to docx

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6871763e262c832db669d03485630962